### PR TITLE
Fix swift compiler error

### DIFF
--- a/EthereumKit.xcodeproj/project.pbxproj
+++ b/EthereumKit.xcodeproj/project.pbxproj
@@ -851,7 +851,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/EthereumKit/ModuleMap $(SRCROOT)/Libraries";
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";


### PR DESCRIPTION
## Why
- When I do `carthage build --no-skip-current`, I got archive failed.
```
...
** ARCHIVE FAILED **


The following build commands failed:
        CompileSwift normal armv7
        CompileSwiftSources normal armv7 com.apple.xcode.tools.swift.compiler
(2 failures)
```

## What
- Change `Swift Compiler - Code Generation's Optimization Level` to `Fast Single-File Optimization [-O]`