### PR TITLE
Add Rinkeby test network

### DIFF
--- a/EthereumKit.xcodeproj/project.pbxproj
+++ b/EthereumKit.xcodeproj/project.pbxproj
@@ -771,7 +771,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 9T7JPNQ2UD;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -792,7 +792,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 9T7JPNQ2UD;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",

--- a/EthereumKit/Helper/Network.swift
+++ b/EthereumKit/Helper/Network.swift
@@ -2,6 +2,7 @@ public enum Network {
     case mainnet
     case ropsten
     case kovan
+    case rinkeby
     case `private`(chainID: Int, testUse: Bool)
     
     public init?(name: String, chainID: Int = 0, testUse: Bool = false) {
@@ -12,6 +13,8 @@ public enum Network {
             self = .ropsten
         case "kovan":
             self = .kovan
+        case "rinkeby":
+            self = .rinkeby
         case "private":
             self = .private(chainID: chainID, testUse: testUse)
         default:
@@ -27,7 +30,7 @@ public enum Network {
         switch self {
         case .mainnet:
             return mainnetCoinType
-        case .ropsten, .kovan:
+        case .ropsten, .kovan, .rinkeby:
             return testnetCoinType
         case .private(_, let testUse):
             return testUse ? testnetCoinType : mainnetCoinType
@@ -41,7 +44,7 @@ public enum Network {
         switch self {
         case .mainnet:
             return mainnetPrefix
-        case .ropsten, .kovan:
+        case .ropsten, .kovan, .rinkeby:
             return testnetPrefix
         case .private(_, let testUse):
             return testUse ? testnetPrefix : mainnetPrefix
@@ -55,7 +58,7 @@ public enum Network {
         switch self {
         case .mainnet:
             return mainnetPrefix
-        case .ropsten, .kovan:
+        case .ropsten, .kovan, .rinkeby:
             return testnetPrefix
         case .private(_, let testUse):
             return testUse ? testnetPrefix : mainnetPrefix
@@ -70,7 +73,9 @@ public enum Network {
             return "Ropsten"
         case .kovan:
             return "Kovan"
-        case .private(_, _):
+        case .rinkeby:
+            return "Rinkeby"
+        case .private:
             return "Privatenet"
         }
     }
@@ -83,6 +88,8 @@ public enum Network {
             return 3
         case .kovan:
             return 42
+        case .rinkeby:
+            return 4
         case .private(let chainID, _):
             return chainID
         }
@@ -92,7 +99,7 @@ public enum Network {
 extension Network: Equatable {
     public static func == (lhs: Network, rhs: Network) -> Bool {
         switch (lhs, rhs) {
-        case (.mainnet, .mainnet), (.ropsten, .ropsten), (.kovan, .kovan):
+        case (.mainnet, .mainnet), (.ropsten, .ropsten), (.kovan, .kovan), (.rinkeby, .rinkeby):
             return true
         case (.private(let firstChainID, let firstTestUse), .private(let secondChainID, let secondTestUse)):
             return firstChainID == secondChainID && firstTestUse == secondTestUse

--- a/EthereumKit/Networking/HTTPClient/Configuration.swift
+++ b/EthereumKit/Networking/HTTPClient/Configuration.swift
@@ -32,6 +32,9 @@ public struct Configuration {
         case .kovan:
             return URL(string: "https://kovan.etherscan.io")!
             
+        case .rinkeby:
+        return URL(string: "https://rinkeby.etherscan.io/")!
+            
         case .private:
             // NOTE: does not get any transactions because of private network.
             return URL(string: "https://ropsten.etherscan.io")!

--- a/EthereumKitTests/NetworkTests.swift
+++ b/EthereumKitTests/NetworkTests.swift
@@ -27,6 +27,14 @@ final class NetworkTests: XCTestCase {
         XCTAssert(network.publicKeyPrefix == 0x043587cf)
     }
     
+    func testRinkeby() {
+        let network = Network.rinkeby
+        XCTAssert(network.chainID == 4)
+        XCTAssert(network.coinType == 1)
+        XCTAssert(network.privateKeyPrefix == 0x04358394)
+        XCTAssert(network.publicKeyPrefix == 0x043587cf)
+    }
+    
     func testPrivateNetTestUse() {
         let network = Network.private(chainID: 100, testUse: true)
         XCTAssert(network.chainID == 100)
@@ -55,6 +63,10 @@ final class NetworkTests: XCTestCase {
         let kovanNetwork = Network(name: "kovan")
         XCTAssertNotNil(kovanNetwork)
         XCTAssertEqual(kovanNetwork, Network.kovan)
+        
+        let rinkebyNetwork = Network(name: "rinkeby")
+        XCTAssertNotNil(rinkebyNetwork)
+        XCTAssertEqual(rinkebyNetwork, Network.rinkeby)
         
         let privateNetwork = Network(name: "private", chainID: 1, testUse: false)
         XCTAssertNotNil(privateNetwork)


### PR DESCRIPTION
I needed the rinkeby test network to a test project and I added to the framework to use it on my project.
Adding the rinkeby as a test network, the etherscan url "https://rinkeby.etherscan.io/" and the tests as well.